### PR TITLE
Fix/readme icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ const hammadKhan = {
 <table>
 <tr>
 <td align="center" width="100">
-<img src="https://raw.githubusercontent.com/devicons/devicon/master/icons/openai/openai-original.svg" width="50"/>
+<img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/openai/openai-original.svg" width="50"/>
 <br><sub>ChatGPT</sub>
 </td>
 <td align="center" width="100">

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ const hammadKhan = {
 </td>
 <td align="center" width="80">
 <a href="https://marketodevdocs.adobe.com/" target="_blank" rel="noreferrer">
-<img src="https://www.vectorlogo.zone/logos/adobe_marketo/adobe_marketo-icon.svg" width="50"/>
+<img src="https://cdn.worldvectorlogo.com/logos/marketo-1.svg" width="50"/>
 <br><sub>Marketo</sub>
 </a>
 </td>


### PR DESCRIPTION

  📋 Summary

  - Fix Marketo icon display issues in README
  - Fix ChatGPT icon display issues in README

  🔧 Changes Made

  Commit 1 (01e598d): Fix Marketo icon display
  - Updated Marketo icon URL from vectorlogo.zone to cdn.worldvectorlogo.com
  - Improves icon reliability and loading performance

  Commit 2 (d014f28): Fix ChatGPT icon display
  - Updated ChatGPT/OpenAI icon URL from raw GitHub to cdn.jsdelivr.net
  - Uses more reliable CDN for consistent icon loading

  🎯 Impact

  - Icons now load more reliably in README
  - Better user experience for profile visitors
  - Uses stable CDN sources instead of potentially unreliable endpoints

  Ready for merge: ✅ All changes tested and working