### PR TITLE
fix(deps): override undici to ^7.28.0 (resolves 6 Dependabot advisories)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8499,9 +8499,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
-      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "js-yaml": "^4.2.0",
     "@babel/core": "^7.29.6",
     "ws": "^8.21.0",
-    "yaml": "^2.8.3"
+    "yaml": "^2.8.3",
+    "undici": "^7.28.0"
   },
   "pnpm": {
     "overrides": {
@@ -59,7 +60,8 @@
       "js-yaml": "^4.2.0",
       "@babel/core": "^7.29.6",
       "ws": "^8.21.0",
-      "yaml": "^2.8.3"
+      "yaml": "^2.8.3",
+      "undici": "^7.28.0"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   '@babel/core': ^7.29.6
   ws: ^8.21.0
   yaml: ^2.8.3
+  undici: ^7.28.0
 
 importers:
 
@@ -2601,8 +2602,8 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  undici@7.24.8:
-    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -5186,7 +5187,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 7.24.8
+      undici: 7.28.0
       workerd: 1.20260507.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
@@ -5782,7 +5783,7 @@ snapshots:
 
   undici-types@7.19.2: {}
 
-  undici@7.24.8: {}
+  undici@7.28.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:


### PR DESCRIPTION
## Summary
Pins transitive `undici` (via `miniflare`/`wrangler`) from **7.24.8 → 7.28.0** in both lockfiles, clearing all 12 open Dependabot alerts (6 unique advisories × 2 lockfiles).

Added `"undici": "^7.28.0"` to both the npm `overrides` and `pnpm.overrides` blocks. Stayed within the 7.x major that miniflare expects (avoids the breaking jump to undici 8.x).

## Advisories resolved
| Severity | GHSA |
|----------|------|
| High | GHSA-hm92-r4w5-c3mj (SOCKS5 proxy pool reuse) |
| High | GHSA-vmh5-mc38-953g (SOCKS5 TLS validation bypass) |
| Medium | GHSA-p88m-4jfj-68fv (Set-Cookie header injection) |
| Medium | GHSA-pr7r-676h-xcf6 (cache whitespace bypass) |
| Low | GHSA-g8m3-5g58-fq7m (SameSite downgrade) |
| Low | GHSA-35p6-xmwp-9g52 (keep-alive queue poisoning) |

## Verification (local)
- `undici@7.28.0` in both lockfiles; `package-lock.json` regenerated via full `npm install` (Linux binaries preserved)
- `npm audit --audit-level=high`: **0 vulnerabilities**
- Lint clean (pre-existing complexity warning only), `astro check`: **0 errors**
- vitest: **750/750 passed**; build: **complete**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency overrides to include `undici` alongside existing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->